### PR TITLE
Flatiron iOS prework

### DIFF
--- a/my-first-lab/FISAppDelegate.m
+++ b/my-first-lab/FISAppDelegate.m
@@ -21,8 +21,8 @@
 // /////////////////////////////////////////////////////
 - (NSString *)didItWork
 {
-    return nil;
-//    return @"YES";
+ //   return nil;
+ return @"YES";
 }
 
 @end


### PR DESCRIPTION
Encountered this error: http://stackoverflow.com/questions/27225586/apple-mach-o-linker-error-in-xcode-6. solved it by making a new schema.
